### PR TITLE
Add continuous expectation demo

### DIFF
--- a/src/components/03-continuous-random-variables/ContinuousExpectation.jsx
+++ b/src/components/03-continuous-random-variables/ContinuousExpectation.jsx
@@ -1,0 +1,176 @@
+"use client";
+import { useState, useEffect, useRef, memo, useCallback } from "react";
+import * as d3 from "d3";
+import { jStat } from "jstat";
+import ExpectationWorkedExample from "./ExpectationWorkedExample";
+
+const margin = { top: 60, right: 40, bottom: 70, left: 60 };
+const width = 800 - margin.left - margin.right;
+const height = 500 - margin.top - margin.bottom;
+
+const distributionOptions = [
+  { value: "normal", label: "Normal", params: [{name: "μ (Mean)", min: -5, max:5, step:0.1, default: 0}, {name: "σ (Std Dev)", min: 0.1, max: 5, step:0.1, default: 1}], pdfTex: "\\frac{1}{\\sigma\\sqrt{2\\pi}} e^{-\\frac{1}{2}\\left(\\frac{x-\\mu}{\\sigma}\\right)^2}" },
+  { value: "exponential", label: "Exponential", params: [{name: "λ (Rate)", min: 0.1, max: 5, step:0.1, default: 1}], pdfTex: "\\lambda e^{-\\lambda x}, \\quad x \\ge 0" },
+  { value: "gamma", label: "Gamma", params: [{name: "k (Shape)", min: 0.1, max:10, step:0.1, default: 2}, {name: "θ (Scale)", min: 0.1, max: 5, step:0.1, default: 1}], pdfTex: "\\frac{1}{\\Gamma(k)\\theta^k} x^{k-1} e^{-x/\\theta}, \\quad x > 0" },
+  { value: "uniform", label: "Uniform", params: [{name: "a (Min)", min: -5, max:5, step:0.1, default: 0}, {name: "b (Max)", min: -4, max: 6, step:0.1, default: 1}], pdfTex: "\\frac{1}{b_0-a_0}, \\quad a_0 \\le x \\le b_0" },
+  { value: "beta", label: "Beta", params: [{name: "α (Alpha)", min: 0.1, max: 10, step:0.1, default: 2}, {name: "β (Beta)", min: 0.1, max: 10, step:0.1, default: 2}], pdfTex: "\\frac{x^{\\alpha-1}(1-x)^{\\beta-1}}{B(\\alpha, \\beta)}, \\quad 0 < x < 1" },
+];
+
+function ContinuousExpectation() {
+  const [selectedDist, setSelectedDist] = useState(distributionOptions[0]);
+  const [params, setParams] = useState(selectedDist.params.map(p => p.default));
+  const svgRef = useRef();
+  const [meanValue, setMeanValue] = useState(0);
+
+  const calculatePlotData = useCallback(() => {
+    let domain, data = [], meanVal;
+    const numPoints = 500;
+    try {
+      switch (selectedDist.value) {
+        case "normal":
+          domain = [params[0] - 4 * params[1], params[0] + 4 * params[1]];
+          data = d3.range(domain[0], domain[1], (domain[1] - domain[0]) / numPoints).map(xVal => ({ x: xVal, y: jStat.normal.pdf(xVal, params[0], params[1]) }));
+          meanVal = jStat.normal.mean(params[0], params[1]);
+          break;
+        case "exponential":
+          domain = [0, Math.max(5 / params[0], 5)];
+          data = d3.range(domain[0], domain[1], (domain[1] - domain[0]) / numPoints).map(xVal => ({ x: xVal, y: jStat.exponential.pdf(xVal, params[0]) }));
+          meanVal = jStat.exponential.mean(params[0]);
+          break;
+        case "gamma":
+          const gammaMean = params[0] * params[1];
+          const gammaStdDev = Math.sqrt(params[0]) * params[1];
+          domain = [Math.max(0.0001, gammaMean - 4 * gammaStdDev), Math.max(gammaMean + 4 * gammaStdDev, 5)];
+          if(domain[0] >= domain[1]) domain = [0.0001, domain[0]+1];
+          data = d3.range(domain[0], domain[1], (domain[1] - domain[0]) / numPoints).map(xVal => ({ x: xVal, y: jStat.gamma.pdf(xVal, params[0], params[1]) }));
+          meanVal = jStat.gamma.mean(params[0], params[1]);
+          break;
+        case "uniform":
+          let [ua, ub] = params;
+          if (ua >= ub) { ub = ua + 0.1; }
+          domain = [ua - (ub-ua)*0.2 - 0.5, ub + (ub-ua)*0.2 + 0.5];
+          data = d3.range(domain[0], domain[1], (domain[1] - domain[0]) / numPoints).map(xVal => ({ x: xVal, y: jStat.uniform.pdf(xVal, ua, ub) }));
+          meanVal = jStat.uniform.mean(ua, ub);
+          break;
+        case "beta":
+          domain = [0, 1];
+          if (params[0] <=0 || params[1] <=0) {
+            data = []; meanVal = 0.5;
+          } else {
+            data = d3.range(0.001, 0.999, (0.999 - 0.001) / numPoints).map(xVal => ({ x: xVal, y: jStat.beta.pdf(xVal, params[0], params[1]) }));
+            meanVal = jStat.beta.mean(params[0], params[1]);
+          }
+          break;
+        default:
+          domain = [-5, 5]; data = []; meanVal = 0;
+      }
+      return { domain, data, meanVal };
+    } catch (error) {
+      console.error("Error calculating distribution data:", error);
+      return { domain: [-5,5], data: [], meanVal: 0 };
+    }
+  }, [selectedDist.value, params]);
+
+  useEffect(() => {
+    const { domain, data: plotData, meanVal } = calculatePlotData();
+    setMeanValue(meanVal);
+
+    d3.select(svgRef.current).selectAll("*").remove();
+
+    const svg = d3.select(svgRef.current)
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom)
+      .append("g")
+      .attr("transform", `translate(${margin.left},${margin.top})`);
+
+    const xScale = d3.scaleLinear().domain(domain).range([0, width]);
+    const maxYValue = d3.max(plotData, d => d.y) || 1;
+    const yScale = d3.scaleLinear().domain([0, maxYValue * 1.1]).range([height, 0]);
+
+    svg.append("g")
+      .attr("transform", `translate(0,${height})`)
+      .call(d3.axisBottom(xScale).ticks(10))
+      .selectAll("text").attr("fill", "#fff").attr("font-size", "12px");
+    svg.append("text").attr("text-anchor", "middle").attr("x", width / 2).attr("y", height + margin.bottom - 20).attr("fill", "#fff").style("font-size", "14px").text("x");
+
+    svg.append("g").call(d3.axisLeft(yScale).ticks(5))
+      .selectAll("text").attr("fill", "#fff").attr("font-size", "12px");
+    svg.append("text").attr("text-anchor", "middle").attr("transform", "rotate(-90)").attr("x", -height / 2).attr("y", -margin.left + 20).attr("fill", "#fff").style("font-size", "14px").text("Density f(x)");
+
+    const line = d3.line().x(d => xScale(d.x)).y(d => yScale(d.y)).curve(d3.curveBasis);
+    const areaGenerator = d3.area().x(d => xScale(d.x)).y0(height).y1(d => yScale(d.y)).curve(d3.curveBasis);
+
+    svg.append("path").datum(plotData).attr("fill", "rgba(20, 184, 166, 0.3)").attr("d", areaGenerator);
+    svg.append("path").datum(plotData).attr("fill", "none").attr("stroke", "#14b8a6").attr("stroke-width", 2.5).attr("d", line);
+
+    if (meanVal !== undefined && xScale(meanVal) >= 0 && xScale(meanVal) <= width) {
+      svg.append("line").attr("x1", xScale(meanVal)).attr("x2", xScale(meanVal)).attr("y1", yScale(0)).attr("y2", yScale(maxYValue * 1.1)).attr("stroke", "#eab308").attr("stroke-width", 2).attr("stroke-dasharray", "4,4");
+      svg.append("text").attr("x", xScale(meanVal) + 5).attr("y", yScale(maxYValue*1.05)).attr("fill", "#eab308").style("font-size", "12px").text(`μ = ${meanVal.toFixed(2)}`);
+    }
+
+    svg.append("text").attr("x", width / 2).attr("y", -margin.top / 2 - 10).attr("text-anchor", "middle").attr("fill", "#fff").style("font-size", "18px").style("font-weight", "bold").text(`${selectedDist.label} Distribution`);
+    selectedDist.params.forEach((paramInfo, index) => {
+      svg.append("text").attr("x", 10).attr("y", -margin.top / 2 + 15 + (index * 18)).attr("fill", "#fff").style("font-size", "12px").text(`${paramInfo.name}: ${params[index].toFixed(2)}`);
+    });
+
+    svg.append("text").attr("x", width - 10).attr("y", -margin.top / 2 + 15).attr("text-anchor", "end").attr("fill", "#fde047").style("font-size", "14px").style("font-weight", "bold").text(`E[X] = ${meanVal.toFixed(4)}`);
+
+    return () => d3.select(svgRef.current).selectAll("*").remove();
+  }, [selectedDist, params, calculatePlotData]);
+
+  const handleDistChange = (e) => {
+    const newDist = distributionOptions.find(opt => opt.value === e.target.value);
+    setSelectedDist(newDist);
+    setParams(newDist.params.map(p => p.default));
+  };
+
+  const handleParamChange = (index, value) => {
+    const newParams = [...params];
+    newParams[index] = parseFloat(value);
+    if (selectedDist.value === "uniform") {
+      if (index === 0 && newParams[0] >= newParams[1]) newParams[1] = newParams[0] + 0.1;
+      else if (index === 1 && newParams[1] <= newParams[0]) newParams[0] = newParams[1] - 0.1;
+    }
+    if (selectedDist.value === "beta") {
+      if (newParams[0] <= 0) newParams[0] = 0.1;
+      if (newParams[1] <= 0) newParams[1] = 0.1;
+    }
+    setParams(newParams);
+  };
+
+  return (
+    <section id="expectation-demo" className="space-y-4 my-8 p-6 bg-neutral-800 rounded-lg shadow-xl">
+      <h3 className="text-xl font-semibold text-teal-400 border-b border-neutral-700 pb-2 mb-6">
+        Expectation of a Continuous Random Variable
+      </h3>
+      <div className="controls grid md:grid-cols-2 gap-6 items-start">
+        <div className="space-y-2">
+          <label htmlFor="dist-select-exp" className="block text-sm font-medium text-neutral-300">Select Distribution:</label>
+          <select id="dist-select-exp" value={selectedDist.value} onChange={handleDistChange} className="w-full p-2 rounded bg-neutral-700 text-white border border-neutral-600 focus:ring-teal-500 focus:border-teal-500">
+            {distributionOptions.map(opt => (<option key={opt.value} value={opt.value}>{opt.label}</option>))}
+          </select>
+        </div>
+        <div className="space-y-4">
+          {selectedDist.params.map((paramInfo, index) => (
+            <div key={paramInfo.name} className="space-y-1">
+              <label htmlFor={`param-exp-${index}`} className="block text-sm font-medium text-neutral-300">
+                {paramInfo.name}: <span className="font-mono text-teal-400">{Number(params[index]).toFixed(2)}</span>
+              </label>
+              <input type="range" id={`param-exp-${index}`} min={paramInfo.min} max={paramInfo.max} step={paramInfo.step} value={params[index]} onChange={(e) => handleParamChange(index, e.target.value)} className="w-full h-2 bg-neutral-700 rounded-lg appearance-none cursor-pointer accent-teal-500"/>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div id="expectation-graph-container" className="mt-6 bg-neutral-900 p-4 rounded-md shadow-inner" style={{width:"100%",maxWidth:"800px", margin:"auto"}}>
+        <svg ref={svgRef} style={{width:"100%", height:"auto", display:"block"}} />
+      </div>
+      <div className="flex justify-center">
+        <ExpectationWorkedExample distName={selectedDist.value} distLabel={selectedDist.label} params={params} pdfFormula={selectedDist.pdfTex} meanValue={meanValue} />
+      </div>
+    </section>
+  );
+}
+
+export default memo(ContinuousExpectation);
+

--- a/src/components/03-continuous-random-variables/ExpectationWorkedExample.jsx
+++ b/src/components/03-continuous-random-variables/ExpectationWorkedExample.jsx
@@ -1,0 +1,88 @@
+"use client";
+import React, { useEffect } from "react";
+import Script from "next/script";
+
+const ExpectationWorkedExample = React.memo(function ExpectationWorkedExample({
+  distName,
+  distLabel,
+  params,
+  pdfFormula,
+  meanValue
+}) {
+  const paramSymbols = {
+    normal: ["\\mu", "\\sigma"],
+    exponential: ["\\lambda"],
+    gamma: ["k", "\\theta"],
+    uniform: ["a_0", "b_0"],
+    beta: ["\\alpha", "\\beta"]
+  };
+
+  const currentParamSymbols = paramSymbols[distName] || [];
+  const paramsString = currentParamSymbols.map((sym, i) => `${sym}=${params[i]?.toFixed(2)}`).join(", ");
+
+  let specificPdfFormula = pdfFormula;
+  if (pdfFormula) {
+    currentParamSymbols.forEach((sym, i) => {
+      const regex = new RegExp(`\\\\${sym.replace('\\', '')}(?!\\w)`, "g");
+      specificPdfFormula = specificPdfFormula.replace(regex, params[i]?.toFixed(2));
+    });
+  }
+
+  const integralSetup = `\\mu = \\mathbb{E}[X] = \\int_{-\\infty}^{\\infty} x f(x; ${paramsString}) \\; dx`;
+  const resultLatex = `${distLabel ? distLabel + ' ' : ''}\\text{mean} = ${meanValue?.toFixed(4)}`;
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.MathJax?.typesetPromise) {
+      window.MathJax.typesetPromise();
+    }
+  }, [distName, params, meanValue, pdfFormula]);
+
+  return (
+    <>
+      <Script
+        id="mathjax-script-expect"
+        src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"
+        strategy="afterInteractive"
+        onLoad={() => {
+          if (typeof window !== "undefined" && window.MathJax) {
+            window.MathJax.typesetPromise();
+          }
+        }}
+      />
+      <div
+        style={{
+          backgroundColor: '#2A303C',
+          padding: '1.5rem',
+          borderRadius: '8px',
+          color: '#e0e0e0',
+          width: '100%',
+          maxWidth: '768px',
+          marginTop: '1.5rem',
+          overflowX: 'auto',
+          fontFamily: 'var(--font-sans)',
+        }}
+        className="text-sm"
+      >
+        <h4 style={{ fontSize: '1.125rem', fontWeight: '600', borderBottom: '1px solid #4A5568', paddingBottom: '0.5rem', marginBottom: '1rem' }}>
+          Expectation Calculation Steps
+        </h4>
+        <div style={{ marginBottom: '1rem' }}>
+          <p style={{ marginBottom: '0.25rem', fontWeight: '500' }}>1. Definition:</p>
+          <div dangerouslySetInnerHTML={{ __html: `\\[${integralSetup}\\]` }} />
+        </div>
+        {specificPdfFormula && (
+          <div style={{ marginBottom: '1rem' }}>
+            <p style={{ marginBottom: '0.25rem', fontWeight: '500' }}>2. Probability Density Function \(f(x)\):</p>
+            <div dangerouslySetInnerHTML={{ __html: `\\[f(x; ${paramsString}) = ${specificPdfFormula}\\]` }} />
+          </div>
+        )}
+        <div style={{ marginBottom: '1rem' }}>
+          <p style={{ marginBottom: '0.25rem', fontWeight: '500' }}>3. Result:</p>
+          <div dangerouslySetInnerHTML={{ __html: `\\[${resultLatex}\\]` }} />
+        </div>
+      </div>
+    </>
+  );
+});
+
+export default ExpectationWorkedExample;

--- a/src/components/03-continuous-random-variables/ExpectationWorkedExample.jsx
+++ b/src/components/03-continuous-random-variables/ExpectationWorkedExample.jsx
@@ -7,7 +7,8 @@ const ExpectationWorkedExample = React.memo(function ExpectationWorkedExample({
   distLabel,
   params,
   pdfFormula,
-  meanValue
+  meanValue,
+  varianceValue
 }) {
   const paramSymbols = {
     normal: ["\\mu", "\\sigma"],
@@ -28,14 +29,17 @@ const ExpectationWorkedExample = React.memo(function ExpectationWorkedExample({
     });
   }
 
-  const integralSetup = `\\mu = \\mathbb{E}[X] = \\int_{-\\infty}^{\\infty} x f(x; ${paramsString}) \\; dx`;
-  const resultLatex = `${distLabel ? distLabel + ' ' : ''}\\text{mean} = ${meanValue?.toFixed(4)}`;
+  const integralSetup = `\\mu = \mathbb{E}[X] = \int_{-\\infty}^{\\infty} x f(x; ${paramsString}) \, dx`;
+  const secondMomentSetup = `\mathbb{E}[X^2] = \int_{-\\infty}^{\\infty} x^2 f(x; ${paramsString}) \, dx`;
+  const ex2Val = varianceValue !== undefined && meanValue !== undefined ? varianceValue + meanValue * meanValue : undefined;
+  const varianceLatex = ex2Val !== undefined ? `\\operatorname{Var}(X) = ${ex2Val.toFixed(4)} - (${meanValue?.toFixed(4)})^2 = ${varianceValue?.toFixed(4)}` : '';
+  const resultLatex = `${distLabel ? distLabel + ' ' : ''}\\mu = ${meanValue?.toFixed(4)}, \; \sigma^2 = ${varianceValue?.toFixed(4)}`;
 
   useEffect(() => {
     if (typeof window !== "undefined" && window.MathJax?.typesetPromise) {
       window.MathJax.typesetPromise();
     }
-  }, [distName, params, meanValue, pdfFormula]);
+  }, [distName, params, meanValue, varianceValue, pdfFormula]);
 
   return (
     <>
@@ -64,7 +68,7 @@ const ExpectationWorkedExample = React.memo(function ExpectationWorkedExample({
         className="text-sm"
       >
         <h4 style={{ fontSize: '1.125rem', fontWeight: '600', borderBottom: '1px solid #4A5568', paddingBottom: '0.5rem', marginBottom: '1rem' }}>
-          Expectation Calculation Steps
+          Expectation & Variance Calculation Steps
         </h4>
         <div style={{ marginBottom: '1rem' }}>
           <p style={{ marginBottom: '0.25rem', fontWeight: '500' }}>1. Definition:</p>
@@ -77,7 +81,15 @@ const ExpectationWorkedExample = React.memo(function ExpectationWorkedExample({
           </div>
         )}
         <div style={{ marginBottom: '1rem' }}>
-          <p style={{ marginBottom: '0.25rem', fontWeight: '500' }}>3. Result:</p>
+          <p style={{ marginBottom: '0.25rem', fontWeight: '500' }}>3. Second Moment:</p>
+          <div dangerouslySetInnerHTML={{ __html: `\\[${secondMomentSetup}\\]` }} />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <p style={{ marginBottom: '0.25rem', fontWeight: '500' }}>4. Variance:</p>
+          <div dangerouslySetInnerHTML={{ __html: `\\[${varianceLatex}\\]` }} />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <p style={{ marginBottom: '0.25rem', fontWeight: '500' }}>5. Results:</p>
           <div dangerouslySetInnerHTML={{ __html: `\\[${resultLatex}\\]` }} />
         </div>
       </div>

--- a/src/components/04-continuous-joint-distributions/ConditionalSliceDemo.jsx
+++ b/src/components/04-continuous-joint-distributions/ConditionalSliceDemo.jsx
@@ -1,0 +1,156 @@
+"use client";
+import { useState, useEffect, useRef, memo } from "react";
+import * as d3 from "d3";
+import Script from "next/script";
+
+const margin = { top: 60, right: 60, bottom: 60, left: 60 };
+const width = 500;
+const height = 300;
+
+function ConditionalSliceDemo() {
+  const [x0, setX0] = useState(0);
+  const [muX, setMuX] = useState(0);
+  const [muY, setMuY] = useState(0);
+  const [sigmaX, setSigmaX] = useState(1);
+  const [sigmaY, setSigmaY] = useState(1);
+  const [rho, setRho] = useState(0);
+  const svgRef = useRef(null);
+  const domain = [-4, 4];
+
+  function condParams(x) {
+    const mean = muY + rho * (sigmaY / sigmaX) * (x - muX);
+    const variance = (1 - rho * rho) * sigmaY * sigmaY;
+    return { mean, variance };
+  }
+
+  function pdfYgivenX(y, x) {
+    const { mean, variance } = condParams(x);
+    const sd = Math.sqrt(variance);
+    return (1 / (sd * Math.sqrt(2 * Math.PI))) * Math.exp(-0.5 * ((y - mean) / sd) ** 2);
+  }
+
+  useEffect(() => {
+    const svg = d3.select(svgRef.current);
+    svg.selectAll("*").remove();
+    svg
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom);
+
+    const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+    const yScale = d3.scaleLinear().domain(domain).range([height, 0]);
+    const xScale = d3.scaleLinear().domain(domain).range([0, width]);
+
+    const yAxis = d3.axisLeft(yScale).ticks(5);
+    const xAxis = d3.axisBottom(xScale).ticks(5);
+
+    g.append("g")
+      .attr("transform", `translate(0,${height})`)
+      .call(xAxis)
+      .selectAll("text")
+      .attr("fill", "#fff");
+
+    g.append("g")
+      .call(yAxis)
+      .selectAll("text")
+      .attr("fill", "#fff");
+
+    const cond = condParams(x0);
+    const sd = Math.sqrt(cond.variance);
+    const yVals = d3.range(domain[0], domain[1], 0.1);
+    const lineData = yVals.map((y) => ({ x: y, y: pdfYgivenX(y, x0) }));
+    const maxY = d3.max(lineData, (d) => d.y) || 1;
+    const pdfScale = d3.scaleLinear().domain([0, maxY * 1.1]).range([0, width / 2]);
+
+    const line = d3.line()
+      .x((d) => pdfScale(d.y))
+      .y((d) => yScale(d.x));
+
+    g.append("path")
+      .datum(lineData)
+      .attr("fill", "none")
+      .attr("stroke", "#38a169")
+      .attr("stroke-width", 2)
+      .attr("d", line);
+
+    g.append("line")
+      .attr("x1", pdfScale(0))
+      .attr("x2", pdfScale(maxY * 1.1))
+      .attr("y1", yScale(cond.mean))
+      .attr("y2", yScale(cond.mean))
+      .attr("stroke", "#eab308")
+      .attr("stroke-dasharray", "4,4");
+
+    g.append("text")
+      .attr("x", width / 2)
+      .attr("y", -20)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#fff")
+      .style("font-size", "16px")
+      .style("font-weight", "bold")
+      .text("Conditional PDF f(y|x)");
+
+    g.append("text")
+      .attr("x", pdfScale(maxY * 1.1))
+      .attr("y", -5)
+      .attr("text-anchor", "end")
+      .attr("fill", "#fde047")
+      .style("font-size", "14px")
+      .text(`x_0=${x0.toFixed(1)}`);
+
+    g.append("text")
+      .attr("transform", "rotate(-90)")
+      .attr("x", -height / 2)
+      .attr("y", -40)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#fff")
+      .text("y");
+
+    g.append("text")
+      .attr("x", width / 4)
+      .attr("y", height + 40)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#fff")
+      .text("Density");
+  }, [x0, muX, muY, sigmaX, sigmaY, rho]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.MathJax?.typesetPromise) {
+      window.MathJax.typesetPromise();
+    }
+  }, [x0, muX, muY, sigmaX, sigmaY, rho]);
+
+  const { mean, variance } = condParams(x0);
+  const formula = `f(y|x_0) = \\mathcal{N}(y; \\mu_y + \\rho \\frac{\\sigma_y}{\\sigma_x}(x_0-\\mu_x), (1-\\rho^2)\\sigma_y^2)`;
+  const meanDisplay = `\\mu_{Y|X=x_0} = ${mean.toFixed(2)}, \\; \text{Var}_{Y|X=x_0} = ${variance.toFixed(2)}`;
+
+  return (
+    <section className="space-y-4 my-8 p-6 bg-neutral-800 rounded-lg shadow-xl">
+      <Script id="mathjax-cond" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" strategy="afterInteractive" />
+      <h3 className="text-lg font-semibold text-teal-400 border-b border-neutral-700 pb-2 mb-6">
+        Conditional Distribution Slice
+      </h3>
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="space-y-2 md:col-span-1">
+          <label className="block text-sm text-neutral-300">x_0: {x0.toFixed(1)}</label>
+          <input type="range" min="-3" max="3" step="0.1" value={x0} onChange={(e)=>setX0(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03BC_x: {muX.toFixed(1)}</label>
+          <input type="range" min="-3" max="3" step="0.1" value={muX} onChange={(e)=>setMuX(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03BC_y: {muY.toFixed(1)}</label>
+          <input type="range" min="-3" max="3" step="0.1" value={muY} onChange={(e)=>setMuY(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03C3_x: {sigmaX.toFixed(1)}</label>
+          <input type="range" min="0.5" max="4" step="0.1" value={sigmaX} onChange={(e)=>setSigmaX(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03C3_y: {sigmaY.toFixed(1)}</label>
+          <input type="range" min="0.5" max="4" step="0.1" value={sigmaY} onChange={(e)=>setSigmaY(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03C1: {rho.toFixed(2)}</label>
+          <input type="range" min="-0.9" max="0.9" step="0.05" value={rho} onChange={(e)=>setRho(parseFloat(e.target.value))} className="w-full" />
+        </div>
+        <div className="md:col-span-2" style={{width:"100%",height:"300px"}}>
+          <svg ref={svgRef} style={{width:"100%",height:"100%"}} />
+        </div>
+      </div>
+      <div className="mt-4 text-neutral-300 text-sm" dangerouslySetInnerHTML={{__html:`\\[${formula}\\]\\[${meanDisplay}\\]`}} />
+    </section>
+  );
+}
+
+export default memo(ConditionalSliceDemo);

--- a/src/components/04-continuous-joint-distributions/JointNormalPDF.jsx
+++ b/src/components/04-continuous-joint-distributions/JointNormalPDF.jsx
@@ -1,0 +1,162 @@
+"use client";
+import { useState, useEffect, useRef, memo } from "react";
+import * as d3 from "d3";
+import Script from "next/script";
+
+const margin = { top: 60, right: 60, bottom: 60, left: 60 };
+const width = 500;
+const height = 500;
+
+function bivariateNormalPDF(x, y, muX, muY, sigmaX, sigmaY, rho) {
+  const norm = 1 / (2 * Math.PI * sigmaX * sigmaY * Math.sqrt(1 - rho * rho));
+  const dx = (x - muX) / sigmaX;
+  const dy = (y - muY) / sigmaY;
+  const exponent = -1 / (2 * (1 - rho * rho)) * (dx * dx - 2 * rho * dx * dy + dy * dy);
+  return norm * Math.exp(exponent);
+}
+
+function JointNormalPDF() {
+  const [muX, setMuX] = useState(0);
+  const [muY, setMuY] = useState(0);
+  const [sigmaX, setSigmaX] = useState(1);
+  const [sigmaY, setSigmaY] = useState(1);
+  const [rho, setRho] = useState(0);
+  const svgRef = useRef(null);
+  const domain = [-4, 4];
+
+  useEffect(() => {
+    const svg = d3.select(svgRef.current);
+    svg.selectAll("*").remove();
+    svg
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom);
+
+    const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+    const xScale = d3.scaleLinear().domain(domain).range([0, width]);
+    const yScale = d3.scaleLinear().domain(domain).range([height, 0]);
+
+    const xAxis = d3.axisBottom(xScale).ticks(5);
+    const yAxis = d3.axisLeft(yScale).ticks(5);
+
+    g.append("g")
+      .attr("transform", `translate(0,${height})`)
+      .call(xAxis)
+      .selectAll("text")
+      .attr("fill", "#fff");
+
+    g.append("g")
+      .call(yAxis)
+      .selectAll("text")
+      .attr("fill", "#fff");
+
+    g.append("text")
+      .attr("x", width / 2)
+      .attr("y", height + 40)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#fff")
+      .text("x");
+
+    g.append("text")
+      .attr("transform", "rotate(-90)")
+      .attr("x", -height / 2)
+      .attr("y", -40)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#fff")
+      .text("y");
+
+    const gridSize = 60;
+    const xVals = d3.range(domain[0], domain[1], (domain[1] - domain[0]) / gridSize);
+    const yVals = d3.range(domain[0], domain[1], (domain[1] - domain[0]) / gridSize);
+    const values = [];
+    let maxPDF = 0;
+    yVals.forEach((y) => {
+      xVals.forEach((x) => {
+        const v = bivariateNormalPDF(x, y, muX, muY, sigmaX, sigmaY, rho);
+        values.push({ x, y, v });
+        if (v > maxPDF) maxPDF = v;
+      });
+    });
+
+    const color = d3.scaleSequential(d3.interpolateViridis).domain([0, maxPDF]);
+
+    g.selectAll("rect")
+      .data(values)
+      .enter()
+      .append("rect")
+      .attr("x", (d) => xScale(d.x))
+      .attr("y", (d) => yScale(d.y + (domain[1] - domain[0]) / gridSize))
+      .attr("width", width / gridSize)
+      .attr("height", height / gridSize)
+      .attr("fill", (d) => color(d.v));
+
+    g.append("line")
+      .attr("x1", xScale(muX))
+      .attr("x2", xScale(muX))
+      .attr("y1", 0)
+      .attr("y2", height)
+      .attr("stroke", "#eab308")
+      .attr("stroke-dasharray", "4,4");
+
+    g.append("line")
+      .attr("y1", yScale(muY))
+      .attr("y2", yScale(muY))
+      .attr("x1", 0)
+      .attr("x2", width)
+      .attr("stroke", "#eab308")
+      .attr("stroke-dasharray", "4,4");
+
+    g.append("text")
+      .attr("x", width / 2)
+      .attr("y", -20)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#fff")
+      .style("font-size", "18px")
+      .style("font-weight", "bold")
+      .text("Bivariate Normal PDF");
+
+    g.append("text")
+      .attr("x", width - 10)
+      .attr("y", -5)
+      .attr("text-anchor", "end")
+      .attr("fill", "#fde047")
+      .style("font-size", "14px")
+      .text(`\u03BC_x=${muX.toFixed(1)}, \u03BC_y=${muY.toFixed(1)}, \u03C3_x=${sigmaX.toFixed(1)}, \u03C3_y=${sigmaY.toFixed(1)}, \u03C1=${rho.toFixed(2)}`);
+  }, [muX, muY, sigmaX, sigmaY, rho]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.MathJax?.typesetPromise) {
+      window.MathJax.typesetPromise();
+    }
+  }, [muX, muY, sigmaX, sigmaY, rho]);
+
+  const pdfFormula = `f(x,y) = \\frac{1}{2\\pi\\sigma_x\\sigma_y\\sqrt{1-\\rho^2}} \\exp\\left(-\\frac{1}{2(1-\\rho^2)}[(\\frac{x-\\mu_x}{\\sigma_x})^2 - 2\\rho(\\frac{x-\\mu_x}{\\sigma_x})(\\frac{y-\\mu_y}{\\sigma_y}) + (\\frac{y-\\mu_y}{\\sigma_y})^2]\\right)`;
+
+  return (
+    <section className="space-y-4 my-8 p-6 bg-neutral-800 rounded-lg shadow-xl">
+      <Script id="mathjax-joint" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" strategy="afterInteractive" />
+      <h3 className="text-xl font-semibold text-teal-400 border-b border-neutral-700 pb-2 mb-6">
+        Joint Continuous Distribution
+      </h3>
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="space-y-2 md:col-span-1">
+          <label className="block text-sm text-neutral-300">\u03BC_x: {muX.toFixed(1)}</label>
+          <input type="range" min="-3" max="3" step="0.1" value={muX} onChange={(e)=>setMuX(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03BC_y: {muY.toFixed(1)}</label>
+          <input type="range" min="-3" max="3" step="0.1" value={muY} onChange={(e)=>setMuY(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03C3_x: {sigmaX.toFixed(1)}</label>
+          <input type="range" min="0.5" max="4" step="0.1" value={sigmaX} onChange={(e)=>setSigmaX(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03C3_y: {sigmaY.toFixed(1)}</label>
+          <input type="range" min="0.5" max="4" step="0.1" value={sigmaY} onChange={(e)=>setSigmaY(parseFloat(e.target.value))} className="w-full" />
+          <label className="block text-sm text-neutral-300">\u03C1: {rho.toFixed(2)}</label>
+          <input type="range" min="-0.9" max="0.9" step="0.05" value={rho} onChange={(e)=>setRho(parseFloat(e.target.value))} className="w-full" />
+        </div>
+        <div className="md:col-span-2" style={{width:"100%",height:"500px"}}>
+          <svg ref={svgRef} style={{width:"100%",height:"100%"}} />
+        </div>
+      </div>
+      <div className="mt-4 text-neutral-300 text-sm" dangerouslySetInnerHTML={{__html:`\\[${pdfFormula}\\]`}} />
+    </section>
+  );
+}
+
+export default memo(JointNormalPDF);

--- a/src/content/probability.mdx
+++ b/src/content/probability.mdx
@@ -139,6 +139,6 @@ As the equation indicates, the *posterior* probability of having the disease giv
 <ContinuousDistributionsPDF />
 </ConceptSection>
 
-<ConceptSection title="Expectation of a Continuous Random Variable">
+<ConceptSection title="Expectation & Variance of a Continuous Random Variable">
 <ContinuousExpectation />
 </ConceptSection>

--- a/src/content/probability.mdx
+++ b/src/content/probability.mdx
@@ -8,6 +8,8 @@ import Bootstrapping from '../components/Bootstrapping.jsx'
 import BayesSimulation from '../components/BayesSimulation';
 import ContinuousDistributionsPDF from '../components/03-continuous-random-variables/ContinuousDistributionsPDF';
 import ContinuousExpectation from '../components/03-continuous-random-variables/ContinuousExpectation';
+import JointNormalPDF from '../components/04-continuous-joint-distributions/JointNormalPDF';
+import ConditionalSliceDemo from '../components/04-continuous-joint-distributions/ConditionalSliceDemo';
 
 
 <div style={{ textAlign: 'center', marginTop: '2rem' }}>
@@ -141,4 +143,20 @@ As the equation indicates, the *posterior* probability of having the disease giv
 
 <ConceptSection title="Expectation & Variance of a Continuous Random Variable">
 <ContinuousExpectation />
+</ConceptSection>
+
+<ConceptSection
+  title="Joint Continuous Distributions"
+  description={
+    <>
+      <p>
+        When dealing with two continuous random variables, their joint behavior is described by a
+        joint probability density function (PDF). Vary the parameters below to explore how
+        correlation shapes the bivariate normal distribution and its conditional slices.
+      </p>
+    </>
+  }
+>
+  <JointNormalPDF />
+  <ConditionalSliceDemo />
 </ConceptSection>

--- a/src/content/probability.mdx
+++ b/src/content/probability.mdx
@@ -7,6 +7,7 @@ import ConfidenceInterval from '../components/ConfidenceInterval.jsx'
 import Bootstrapping from '../components/Bootstrapping.jsx'
 import BayesSimulation from '../components/BayesSimulation';
 import ContinuousDistributionsPDF from '../components/03-continuous-random-variables/ContinuousDistributionsPDF';
+import ContinuousExpectation from '../components/03-continuous-random-variables/ContinuousExpectation';
 
 
 <div style={{ textAlign: 'center', marginTop: '2rem' }}>
@@ -134,6 +135,10 @@ As the equation indicates, the *posterior* probability of having the disease giv
 </ConceptSection>
 
 
-<ConceptSection title="Continuous Distributions"> 
+<ConceptSection title="Continuous Distributions">
 <ContinuousDistributionsPDF />
+</ConceptSection>
+
+<ConceptSection title="Expectation of a Continuous Random Variable">
+<ContinuousExpectation />
 </ConceptSection>


### PR DESCRIPTION
## Summary
- import new components
- implement `ContinuousExpectation` visualization with D3 and jStat
- show worked example in `ExpectationWorkedExample`
- add new concept section in MDX

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f68985190832298e36bce24fbe06e